### PR TITLE
Bug Fix: score update

### DIFF
--- a/app.js
+++ b/app.js
@@ -178,10 +178,10 @@ const game2048 = {
     },
     popBothTiles: function (tile1, tile2, idx, direction, updateClasses) {
         if (updateClasses) {
+            const oldValue = parseInt(tile1.innerText);
+            const newValue = 2 * oldValue;
+            this.score += newValue;
             tile2.addEventListener('transitionend', () => {
-                oldValue = parseInt(tile1.innerText);
-                newValue = 2 * oldValue;
-                this.score += newValue;
                 tile1.innerText = newValue.toLocaleString();
                 tile1.classList.replace(`color${oldValue}`, `color${newValue}`);
                 tile2.remove();


### PR DESCRIPTION
fix bug where score updates one move late by moving the code that updates the score outside of the `transitionend` event listener